### PR TITLE
Rebased unitNPerfTests onto dev at 9516676

### DIFF
--- a/+sig/+node/Signal.m
+++ b/+sig/+node/Signal.m
@@ -286,10 +286,12 @@ classdef Signal < sig.Signal & handle
     end
     
     function fs = flatten(this)
-      % Returns a signal `fs` whose value is a "flattened" version of 
-      % `this`'s value. `this` is a subscriptable signal field whose value 
-      % is another signal. In other words, `flatten` "flattens" `this`'s 
-      % value - a signal - down to the value it holds.
+      % Flattens a nested signal down to its value.
+      % 
+      % Returns a signal `fs` whose value is a flattened version of 
+      % `this`'s value: if `this` is a signal whose value is another 
+      % signal, `s`, `fs` will take the value that `s` holds, rather than 
+      % taking the value of `s` itself.
       
       state = StructRef;
       state.unappliedInputChanges = false;
@@ -298,19 +300,18 @@ classdef Signal < sig.Signal & handle
     end
     
     function fs = flattenStruct(this)
+      % Flattens nested signal fields down to their values.
+      %
       % Returns a signal `fs` whose value is a struct containing 
-      % "flattened" field values for the signal fields in `this`. In other
-      % words, `flattenStruct` "flattens" signal fields down to the values 
-      % they hold. (`this` can be a subscriptable signal, or a signal whose 
-      % value is a struct containing some signal fields). 
+      % flattened values for the signal fields in `this`: if `this` is a 
+      % subscriptable signal or a signal whose value is a struct containing
+      % some signal fields, `fs` takes the value those signal fields hold, 
+      % rather than taking the value of the signal fields themselves.
       %
       % `fs` uses `this` as a blueprint to wire up signals as inputs to
       % itself. The values of the signal fields in `this` will be directly 
       % set as `fs`'s struct field values. This is done in mexnet according
       % to the transfer opCode.
-      %
-      % Like `flatten`, but works on `this` directly, rather than `this`'s 
-      % signal fields.
       
       fs = applyTransferFun(this, 'sig.transfer.flattenStruct', [], '%s.flattenStruct()');
 

--- a/+sig/+node/Signal.m
+++ b/+sig/+node/Signal.m
@@ -285,27 +285,35 @@ classdef Signal < sig.Signal & handle
       id.Node.DisplayInputs = this.Node.DisplayInputs;
     end
     
-    function fs = flattenStruct(this)
-      % Returns a signal `fs` whose value is a struct containing 
-      % "flattened" fields for the signal fields in the struct that 
-      % `this` has as its value. 
-      %
-      % Uses a signal (whose value is a struct with signal fields) as a 
-      % blueprint to wire up signals as inputs to this target. The values
-      % of these signal fields will be directly set as the target signal's
-      % struct field values. This is done in mexnet according to the 
-      % transfer opCode.
-      
-      fs = applyTransferFun(this, 'sig.transfer.flattenStruct', [], '%s.flattenStruct()');
-
-    end
-
     function fs = flatten(this)
-
+      % Returns a signal `fs` whose value is a "flattened" version of 
+      % `this`'s value. `this` is a subscriptable signal field whose value 
+      % is another signal. In other words, `flatten` "flattens" `this`'s 
+      % value - a signal - down to the value it holds.
+      
       state = StructRef;
       state.unappliedInputChanges = false;
       fs = applyTransferFun(this, 'sig.transfer.flatten', state,...
         '%s.flatten()');
+    end
+    
+    function fs = flattenStruct(this)
+      % Returns a signal `fs` whose value is a struct containing 
+      % "flattened" field values for the signal fields in `this`. In other
+      % words, `flattenStruct` "flattens" signal fields down to the values 
+      % they hold. (`this` can be a subscriptable signal, or a signal whose 
+      % value is a struct containing some signal fields). 
+      %
+      % `fs` uses `this` as a blueprint to wire up signals as inputs to
+      % itself. The values of the signal fields in `this` will be directly 
+      % set as `fs`'s struct field values. This is done in mexnet according
+      % to the transfer opCode.
+      %
+      % Like `flatten`, but works on `this` directly, rather than `this`'s 
+      % signal fields.
+      
+      fs = applyTransferFun(this, 'sig.transfer.flattenStruct', [], '%s.flattenStruct()');
+
     end
     
     function tr = applyTransferFun(varargin)
@@ -317,18 +325,20 @@ classdef Signal < sig.Signal & handle
       %
       % Transfer functions work at a lower level than transformations like 
       % `map` or `mapn`, instead operating directly with the underlying 
-      % input nodes and output node,potentially using both their current 
+      % input nodes and output node, potentially using both their current 
       % *and* new values.
       %
       % [tr] = s1.applyTransferFun([s2], ..., funName, funArg, formatSpec)
       % 
       % Inputs:
-      %   `varargin`: contains one (or more) input values/signals, `sigs`, 
-      %   used to create the output signal; a string, `funName`, of the
-      %   transfer function; an optional function handle, `funArg`, which
-      %   can be applied by the transfer function, and an optional string
-      %   `formatSpec`, which is used to format the name of the output
-      %   signal
+      %   `s2`: an input value/signal (there can be multiple as separate 
+      %   args)
+      %   `funName`: a string of the name of the transfer function to be 
+      %   applied 
+      %   `funArg`: an optional function handle which can be applied by the
+      %   transfer function
+      %   `formatSpec`: an optional string which is used to format the name 
+      %   of the output signal
       %
       % Outputs: `tr`: output signal
       %

--- a/tests/Signals_perftest.m
+++ b/tests/Signals_perftest.m
@@ -142,9 +142,8 @@ classdef Signals_perftest < matlab.perftest.TestCase
         case {'scan'}
           c = feval(SignalOps, testCase.A, @plus, 0);
         case {'flatten'}
-          s = testCase.Net.subscriptableOrigin('s'); % create a subscriptable signal
-          post(testCase.B, 0);
-          s_flat = feval(SignalOps, s.field);
+          b_flat = feval(SignalOps, testCase.B);
+          testCase.B.post(testCase.A);
       end
       
       % test time it takes for method to update `c`:
@@ -160,11 +159,12 @@ classdef Signals_perftest < matlab.perftest.TestCase
           % special case: have to use `runSchedule`     
           while (testCase.keepMeasuring)
             for i = 1:testCase.Reps
+              post(testCase.A, 1);
               testCase.Net.runSchedule();
             end
           end
         case {'flatten'}
-          % special case: have to assign a signal to `s_flat`
+          % special case: have to assign a signal to `s_field` to update `s_flat`
           while (testCase.keepMeasuring)
             for i = 1:testCase.Reps
               s.field = testCase.B;

--- a/tests/Signals_perftest.m
+++ b/tests/Signals_perftest.m
@@ -163,13 +163,6 @@ classdef Signals_perftest < matlab.perftest.TestCase
               testCase.Net.runSchedule();
             end
           end
-        case {'flatten'}
-          % special case: have to assign a signal to `s_field` to update `s_flat`
-          while (testCase.keepMeasuring)
-            for i = 1:testCase.Reps
-              s.field = testCase.B;
-            end
-          end
         otherwise
           while (testCase.keepMeasuring)
             for i = 1:testCase.Reps


### PR DESCRIPTION
parent 951667690a9bc0f00d2f4a3b95723323ef003688
author jaib1 <j.bhagat@ucl.ac.uk> 1558098592 +0100
committer jaib1 <j.bhagat@ucl.ac.uk> 1564008156 +0100

added 2nd Signals perf test

added test results table for perf test

removed 'echo' from 'checkForUpdate'

small updates before benchmarking ACW

updated Signals_perftest

minor updates to Signals_perftest

updated identity test

updated identity test

fixed horrendous bug in perfTest 'test_networkOps' and added benchmark results from new lilrig

fixes to perftest

depth fix for perftest

bug fix for perftest

fix for 'onValue' in perfTest

added new results table to 'signals/tests/results1 for perftest

update to signalsPong based on Miles' suggestions from paper

doc changes to 'applyTransferFun'

WIP 'Signals_perftest/test_network' for ALL operations

done new version of 'Signals_perftest' pre-testing

ready for another Miles review : )

removed unnecessary tab

updated perftest for 'delay' and 'flatten'