### PR TITLE
added an informative error message in the case that dat.paths is missing

### DIFF
--- a/+exp/test.m
+++ b/+exp/test.m
@@ -6,6 +6,9 @@ addSignalsJava();
 global AGL GL GLU %#ok<NUSED>
 persistent defdir lastParams;
 
+% Check that paths are set up
+assert(~isempty(which('dat.paths')), ...
+    'Error: dat.paths not found. Please ensure that a paths file exists for your setup. A template can be found at docs/setup/paths_template')
 
 if isempty(defdir)
   defdir = getOr(dat.paths, 'expDefinitions'); %FIXME If we decide to keep Signals independent of Rigbox this should change

--- a/+exp/test.m
+++ b/+exp/test.m
@@ -8,6 +8,7 @@ persistent defdir lastParams;
 
 % Check that paths are set up
 assert(~isempty(which('dat.paths')), ...
+    'signals:test:copyPaths',...
     'Error: dat.paths not found. Please ensure that a paths file exists for your setup. A template can be found at docs/setup/paths_template')
 
 if isempty(defdir)


### PR DESCRIPTION
If the user has failed to set up dat.paths, Rigbox currently generates confusing and uninformative error messages. I added a more informative one here. (In general, I'm going to try and add informative error messages every time I get an uninformative one -- let me know if you think this isn't helpful!)